### PR TITLE
fix: lexical editor internal links

### DIFF
--- a/src/payload/fields/defaultLexical.ts
+++ b/src/payload/fields/defaultLexical.ts
@@ -29,7 +29,7 @@ export const defaultLexical: Config['editor'] = lexicalEditor({
               name: 'url',
               type: 'text',
               admin: {
-                condition: ({ linkType }) => linkType !== 'internal',
+                condition: (_data, siblingData) => siblingData?.linkType !== 'internal',
               },
               label: ({ t }) => t('fields:enterURL'),
               required: true,


### PR DESCRIPTION
Fixes #3 
I got the fix by copying the [official website template `defaultLexical.ts`](https://github.com/payloadcms/payload/blob/main/templates/website/src/fields/defaultLexical.ts).